### PR TITLE
check types for evaluator params

### DIFF
--- a/src/Evaluator/Evaluator.ts
+++ b/src/Evaluator/Evaluator.ts
@@ -32,9 +32,19 @@ export class Evaluator {
    * @return The evaluated expression.
    */
   public evaluate(expression: string, context: object | string): string {
+		// check types
+		if (typeof expression !== 'string') {
+			throw new EvaluatorError(`Expression must be a string, got ${typeof expression}`)
+		}
+
     if (typeof context === 'string') {
       context = this.deserializeContextOrThrow(context)
     }
+
+		if (typeof context !== 'object') {
+			throw new EvaluatorError(`Expression Context must be an object, got ${typeof context}`)
+		}
+
     // iterate through the expression context and convert all date strings into moment date objects
     if (context['date'] !== undefined) {
       for (const [k, v] of Object.entries(context['date'])) {

--- a/tests/Evaluator.test.ts
+++ b/tests/Evaluator.test.ts
@@ -83,3 +83,11 @@ it('bug scrub', () => {
 
   expect(evaluator.evaluate(e, c)).toBeTruthy()
 })
+
+it('throws something on undefined input', () => {
+	//@ts-ignore
+	expect(() => {evaluator.evaluate(undefined, {})}).toThrow()
+
+	//@ts-ignore
+	expect(() => {evaluator.evaluate('', undefined)}).toThrow()
+})

--- a/tests/Evaluator/NodeEvaluator/MemberNodeEvaluator.test.ts
+++ b/tests/Evaluator/NodeEvaluator/MemberNodeEvaluator.test.ts
@@ -249,3 +249,16 @@ it('should treat undefined properties as not existing', () => {
   }
   expect(evaluator.evaluate(node, ctx)).toEqual('flow.block.value')
 })
+
+it('should treat undefined magic properties as not existing', () => {
+	const node = makeNode('flow.contact')
+	const ctx = {
+		contact: {
+			name: {
+				value: undefined,
+				__value__: undefined
+			}
+		}
+	}
+	expect(evaluator.evaluate(node, ctx)).toEqual('flow.contact')
+})


### PR DESCRIPTION
Prior to this change, passing 'undefined' as the expression will result in a pretty useless PEG parsing error.
This error is more informative.