### PR TITLE
VMO-3449 allow nested context objects to be used in array functions

### DIFF
--- a/src/Evaluator/NodeEvaluator/MemberNodeEvaluator.ts
+++ b/src/Evaluator/NodeEvaluator/MemberNodeEvaluator.ts
@@ -1,4 +1,4 @@
-import {Member, Node, NodeEvaluator, NodeShapeError,} from '../..'
+import {Member, MemberObject, Node, NodeEvaluator, NodeShapeError,} from '../..'
 import moment from "moment"
 
 export const MEMBER_TYPE = 'MEMBER'
@@ -43,7 +43,7 @@ export class MemberNodeEvaluator implements NodeEvaluator {
       } else if (moment.isMoment(currentContext)) {
         return currentContext
       } else {
-        return JSON.stringify(currentContext)
+        return new MemberObject(currentContext)
       }
     } else if (typeof currentContext === 'undefined') {
       // if we hit an undefined value, just return the compound key

--- a/src/Evaluator/NodeEvaluator/MemberNodeEvaluator/MemberObject.ts
+++ b/src/Evaluator/NodeEvaluator/MemberNodeEvaluator/MemberObject.ts
@@ -1,0 +1,36 @@
+/**
+ * Provides iteration of object-like expression values and just-in-time serialization
+ */
+export class MemberObject implements Iterable<any> {
+	constructor(private data: Object) {}
+
+	// when we iterate over this object, we want to grab the __value__
+	// of any objects it has as children
+	*iterator() {
+		for (let item of Object.values(this.data)) {
+			if (typeof item === 'object' && '__value__' in item) {
+				yield item['__value__']
+			} else {
+				yield item
+			}
+		}
+	}
+
+	// we implement iterable so that we can handle expression objects
+	// that are array-like
+	[Symbol.iterator](): Iterator<any, any, undefined>  {
+		return this.iterator()
+	}
+
+	public toString() {
+		return JSON.stringify(this.data)
+	}
+
+	public toJSON() {
+		return JSON.stringify(this.data)
+	}
+
+	get length(): number {
+		return Object.keys(this.data).length
+	}
+}

--- a/src/Evaluator/NodeEvaluator/MethodNodeEvaluator/MethodNodeHandlers/ArrayHandler.ts
+++ b/src/Evaluator/NodeEvaluator/MethodNodeEvaluator/MethodNodeHandlers/ArrayHandler.ts
@@ -19,12 +19,23 @@ export class ArrayHandler extends AbstractNodeHandler {
       search = array.value
     }
 
-    if (!Array.isArray(search)) {
-      throw new NodeEvaluatorError(`Can only perform IN on an array, got ${typeof search}`)
-    } else {
-      // we use some instead of includes for loose comparison
-      return (search).some((item) => item == value)
+    if (!(Array.isArray(search) || this.isIterable(search))) {
+      throw new NodeEvaluatorError(`Can only perform IN on an array or iterable, got ${typeof search}`)
     }
+
+    for (let val of (search as Iterable<any>)) {
+      if (String(val) === String(value)) {
+          return true
+      }
+    }
+  return false
+  }
+
+  private isIterable(obj) {
+    if (obj == null) {
+        return false
+    }
+    return typeof obj[Symbol.iterator] === 'function'
   }
 
   public count(array: Node | any[]): number {
@@ -33,10 +44,10 @@ export class ArrayHandler extends AbstractNodeHandler {
       arr = array.value
     }
 
-    if (!Array.isArray(arr)) {
+    if (!(Array.isArray(arr) || 'length' in arr)) {
       throw new NodeEvaluatorError(`Can only perform COUNT on an array, got ${typeof arr}`)
     } else {
-      return arr.length
+      return (arr as Array<any>).length
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,4 @@ export * from './Evaluator/NodeEvaluator/MethodNodeEvaluator/MethodNodeHandlers/
 export * from './Evaluator/NodeEvaluator/MethodNodeEvaluator/MethodNodeHandlers/LogicalHandler'
 export * from './Evaluator/NodeEvaluator/MethodNodeEvaluator/MethodNodeHandlers/MathHandler'
 export * from './Evaluator/NodeEvaluator/MethodNodeEvaluator/MethodNodeHandlers/TextHandler'
+export * from './Evaluator/NodeEvaluator/MemberNodeEvaluator/MemberObject'

--- a/tests/Evaluator.test.ts
+++ b/tests/Evaluator.test.ts
@@ -83,3 +83,8 @@ it('bug scrub', () => {
 
   expect(evaluator.evaluate(e, c)).toBeTruthy()
 })
+
+it('true/false mcq', () => {
+	expect(evaluator.evaluate('True', {})).toBe('True')
+	expect(evaluator.evaluate('False', {})).toBe('False')
+})

--- a/tests/Evaluator/EvaluatorIntegration.test.ts
+++ b/tests/Evaluator/EvaluatorIntegration.test.ts
@@ -501,3 +501,35 @@ describe.each(stringDateMathProvider)(
     })
   }
 )
+
+it('testInGroupsNestedMemberObject', () => {
+	const trueCase = '@(IN(groups.group, contact.groups))'
+	const falseCase = '@(IN(groups.group2, contact.groups))'
+	const context = {
+		'groups': {
+			'group': {
+				'__value__': 'group0'
+			},
+			'group1': {
+				'__value__': 'group1'
+			},
+			'group2': {
+				'__value__': 'group2'
+			}
+		},
+		'contact': {
+			'groups': {
+				'group0': {
+					'__value__': 'group0'
+				},
+				'group1': {
+					'__value__': 'group1'
+				}
+			}
+		}
+	}
+
+	expect(evaluator.evaluate(trueCase, context)).toBe('TRUE');
+	expect(evaluator.evaluate(falseCase, context)).toBe('FALSE')
+	expect(evaluator.evaluate('@(COUNT(contact.groups))', context)).toBe('2')
+})

--- a/tests/Evaluator/NodeEvaluator/MemberNodeEvaluator.test.ts
+++ b/tests/Evaluator/NodeEvaluator/MemberNodeEvaluator.test.ts
@@ -44,12 +44,12 @@ const keysNoValueProvider: Array<[Node, object, string]> = [
 ]
 
 describe.each(keysNoValueProvider)(
-  '%#: node: %o context: %o => %s',
-  (node, context, expected) => {
-    it('evaluates member node with key and no value', () => {
-      expect(evaluator.evaluate(node, context)).toEqual(expected);
-    })
-  }
+	'%#: node: %o context: %o => %s',
+	(node, context, expected) => {
+		it('evaluates member node with key and no value', () => {
+			expect(JSON.stringify(evaluator.evaluate(node, context))).toEqual(JSON.stringify(expected));
+		})
+	}
 )
 
 const keysDefaultValueProvider: Array<[Node, object, string]> = [
@@ -194,12 +194,12 @@ const nestedContextProvider: Array<[Node, object, string]> = [
 ]
 
 describe.each(nestedContextProvider)(
-  '%#: node: %o context: %o => %s',
-  (node, context, expected) => {
-    it('evaluates nested context', () => {
-      expect(evaluator.evaluate(node, context)).toEqual(expected);
-    })
-  }
+	'%#: node: %o context: %o => %s',
+	(node, context, expected) => {
+		it('evaluates nested context', () => {
+			expect(JSON.stringify(evaluator.evaluate(node, context))).toEqual(JSON.stringify(expected));
+		})
+	}
 )
 
 const numericKeyProvider: Array<[Node, object, string]> = [


### PR DESCRIPTION
"@(IN(groups.group, contact.groups))"

This should work ,but doesn't because:
contact.groups is being coerced into a JSON string.

Solution:
Don't cast object-like values into JSON immediately, do it just-in-time.
Allow the object-like values to be iterated over and expose any child objects value

New test + old tests pass locally.