### PR TITLE
VMO-3796 fix excellent string handling

### DIFF
--- a/src/Evaluator/NodeEvaluator/MethodNodeEvaluator/MethodNodeHandlers/ExcellentHandler.ts
+++ b/src/Evaluator/NodeEvaluator/MethodNodeEvaluator/MethodNodeHandlers/ExcellentHandler.ts
@@ -32,10 +32,11 @@ export class ExcellentHandler implements MethodNodeHandler {
   }
 
   public remove_fist_word(string: string): string {
-    return string.substr(this.first_word(string).length)
+    return String(string).substr(this.first_word(string).length)
   }
 
   public word(string: string, number: number, bySpaces?: boolean): string {
+    string = String(string)
     const split = bySpaces ? string.split(' ') : this.splitByPunc(string)
 
     if (number < 0) {
@@ -46,17 +47,18 @@ export class ExcellentHandler implements MethodNodeHandler {
   }
 
   private splitByPunc(string: string): Array<string> {
-    return string.split(/\s*[,:;!?.-]\s*|\s/g).filter(a => a)
+    return String(string).split(/\s*[,:;!?.-]\s*|\s/g).filter(a => a)
   }
 
   public word_count(string: string, bySpaces?: boolean): number {
     if (bySpaces) {
-      return string.split(' ').length
+      return String(string).split(' ').length
     }
     return this.splitByPunc(string).length
   }
 
   public word_slice(string: string, start: number, stop?: number, bySpaces?: boolean): string {
+    string = String(string)
     let split = bySpaces ? string.split(' ') : this.splitByPunc(string)
 
     if (typeof stop === 'undefined') {

--- a/tests/Evaluator/EvaluatorIntegration.test.ts
+++ b/tests/Evaluator/EvaluatorIntegration.test.ts
@@ -493,6 +493,15 @@ const stringDateMathProvider: Array<[string, object, string]> = [
   ]
 ]
 
+it('casts string on split_word', () => {
+  const now = (new Date('2020-01-01 00:00:00')).getTime()
+  jest.spyOn(Date, 'now').mockReturnValue(now)
+
+  const expected = "Today in simple date: Jan 01 2020"
+
+  expect(evaluator.evaluate("Today in simple date: @(word_slice(today(),2,5,true))", {})).toBe(expected)
+})
+
 describe.each(stringDateMathProvider)(
   'string math %#',
   (expression, context, expected) => {

--- a/tests/Evaluator/EvaluatorIntegration.test.ts
+++ b/tests/Evaluator/EvaluatorIntegration.test.ts
@@ -493,7 +493,7 @@ const stringDateMathProvider: Array<[string, object, string]> = [
   ]
 ]
 
-it('casts string on split_word', () => {
+it('casts string on word_slice', () => {
   const now = (new Date('2020-01-01 00:00:00')).getTime()
   jest.spyOn(Date, 'now').mockReturnValue(now)
 


### PR DESCRIPTION
`Today in simple date: @(word_slice(today(),2,5,true))` causes a crash at runtime.
This is because `split` is being called on the return of `today()`, which is a `moment` object, not a string.
So we will explicitely stringify our variables before using them as strings.